### PR TITLE
Automatically detect cores in build_ffmpeg_android.sh make section

### DIFF
--- a/TMessagesProj/jni/build_ffmpeg_android.sh
+++ b/TMessagesProj/jni/build_ffmpeg_android.sh
@@ -64,7 +64,7 @@ $ADDITIONAL_CONFIGURE_FLAG
 
 #echo "continue?"
 #read
-make -j8
+make -j$(nproc)
 make install
 
 }
@@ -115,5 +115,3 @@ OPTIMIZE_CFLAGS="-march=$CPU"
 PREFIX=./android/$CPU
 ADDITIONAL_CONFIGURE_FLAG="--disable-mmx --disable-yasm"
 build_one
-
-


### PR DESCRIPTION
Hi, I've just noticed that your script had static value of `-j`, not all users have 8 threads

It will detect threads/cores properly