### PR TITLE
Warn about Building under Windows more noticably

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ MTproto protocol manuals: https://core.telegram.org/mtproto
       - Take good care of your users' data and privacy
       - **Please remember to publish your code too in order to comply with the licenses**
 
-6. Building under Windows may be problematic and won't be fixed
+6. ![Building under Windows may be problematic and won't be fixed](https://storage.theel0ja.info/imgup-syncthing/tgfoss-build-under-win.gif)
 
 The project can be built with Android Studio or from the command line with gradle:
 


### PR DESCRIPTION
nobody seems to notice that windows won't work:

<img width="919" alt="screen shot 2018-09-05 at 18 37 54" src="https://user-images.githubusercontent.com/5832930/45104466-d5eb7e80-b13a-11e8-89de-3e299a7b3038.png">

<img width="345" alt="screen shot 2018-09-05 at 18 38 48" src="https://user-images.githubusercontent.com/5832930/45104514-f4517a00-b13a-11e8-8aa8-86526106a9cd.png">

https://github.com/Telegram-FOSS-Team/Telegram-FOSS/tree/519e4e3396f2afbdba0ee4528fd37c72ce028848#building

The amazing graphics used to these changes are [open source](https://gist.github.com/theel0ja/6fe9dbd2d4a8a3d45a4ec80721313896).