### PR TITLE
aktualigis priskribojn (eo+pl) | updated descriptions (eo+pl)

### DIFF
--- a/metadata/eo/description.txt
+++ b/metadata/eo/description.txt
@@ -4,10 +4,10 @@ Kliento por la mesaĝ‑sistemo Telegramo. Babili kun amikoj, ekigi grupajn babi
 
 La mesaĝ‑sistemo estas projektita por poŝtelefonoj, tamen komputilaj kaj enretaj klientoj ankaŭ disponeblas.
 
-Kelkaj fermkodaj partoj estis forigitaj el la originala kliento Telegramo, inkluzive servoj Google Play (por trovi pozicion), HockeySDK (por mem-ĝisdatigoj) kaj puŝsciigoj per Google Cloud Messaging. Eblo por kunhavigi pozicion funkcias per OpenStreetMap.
+Kelkaj fermkodaj partoj estis forigitaj el la originala kliento Telegramo, inkluzive servojn Google Play (por trovi pozicion), HockeySDK (por mem-ĝisdatigoj) kaj puŝsciigojn per Google Cloud Messaging. Eblo por kunhavigi pozicion funkcias per OpenStreetMap.
 
 Fieblo: nelibera reto, ĉar serviloj funkcias per fermkoda programaro.
 
 La oficiala fontkodo enhavas binaraĵojn, en tiu ĉi ido oni kompilis ilin el fontkodoj.
 
-Neoficiala esperantigo: <a href="https://t.me/setlanguage/eo-beta">https://t.me/setlanguage/eo-beta</a>
+Neoficiala esperantigo: <a href="https://t.me/setlanguage/eo-beta">https://t.me/setlanguage/eo-beta</a>.

--- a/metadata/eo/description.txt
+++ b/metadata/eo/description.txt
@@ -1,11 +1,13 @@
-'''Averto:''' tiu ĉi kompilaĵo estas plene libera ido, la originaj programistoj ofte malfrue publikigas la fontkodon de plej novaj versioj.
+<b>Averto:</b> tiu ĉi kompilaĵo estas plene libera ido, programistoj de la oficiala kliento ofte malfrue publikigas la fontkodon de la plej novaj versioj, do la novaj versioj estas eldonataj kun ioma prokrasto.
 
-Kliento por la mesaĝ-sistemo Telegramo. Babili kun amikoj, ekigi grupajn babilejojn kaj kunhavigi ian ajn specon de enhavo. Ĉiuj viaj mesaĝoj kaj interparoladoj estas konservataj en la Telegraman nubon.
+Kliento por la mesaĝ‑sistemo Telegramo. Babili kun amikoj, ekigi grupajn babilejojn kaj kunhavigi ian ajn specon de enhavo. Ĉiuj viaj mesaĝoj kaj interparoladoj estas konservataj en la Telegram-nubon.
 
-La mesaĝ-sistemo estas projektita por poŝtelefonoj, tamen komputilaj kaj enretaj klientoj ankaŭ disponeblas.
+La mesaĝ‑sistemo estas projektita por poŝtelefonoj, tamen komputilaj kaj enretaj klientoj ankaŭ disponeblas.
 
-Kelkaj fermkodaj partoj estis forigitaj el la originala kliento Telegramo, inkluzive Google Play Services (por trovi pozicion), HockeySDK (por mem-ĝisdatigoj) kaj puŝatentigoj per Google Cloud Messaging. Eblo por kunhavigi pozicion funkcias per OpenStreetMap.
+Kelkaj fermkodaj partoj estis forigitaj el la originala kliento Telegramo, inkluzive servoj Google Play (por trovi pozicion), HockeySDK (por mem-ĝisdatigoj) kaj puŝsciigoj per Google Cloud Messaging. Eblo por kunhavigi pozicion funkcias per OpenStreetMap.
 
 Fieblo: nelibera reto, ĉar serviloj funkcias per fermkoda programaro.
 
-La oficiala fontkodo enhavas binaraĵojn, do en tiu ĉi ido oni kompilis ilin el fontkodoj. Do tial novaj versioj estas eldonataj kun kelka prokrasto.
+La oficiala fontkodo enhavas binaraĵojn, do en tiu ĉi ido oni kompilis ilin el fontkodoj.
+
+Neoficiala esperantigo: <a href="https://t.me/setlanguage/eo-beta">https://t.me/setlanguage/eo-beta</a>

--- a/metadata/eo/description.txt
+++ b/metadata/eo/description.txt
@@ -4,7 +4,7 @@ Kliento por la mesaĝ‑sistemo Telegramo. Babili kun amikoj, ekigi grupajn babi
 
 La mesaĝ‑sistemo estas projektita por poŝtelefonoj, tamen komputilaj kaj enretaj klientoj ankaŭ disponeblas.
 
-Kelkaj fermkodaj partoj estis forigitaj el la originala kliento Telegramo, inkluzive servojn Google Play (por trovi pozicion), HockeySDK (por mem-ĝisdatigoj) kaj puŝsciigojn per Google Cloud Messaging. Eblo por kunhavigi pozicion funkcias per OpenStreetMap.
+Kelkaj fermkodaj partoj estis forigitaj el la originala kliento Telegramo, inkluzive servojn Google Play (por trovi pozicion), HockeySDK (por mem-ĝisdatigoj) kaj Google Cloud Messaging (por puŝsciigoj). Eblo por kunhavigi pozicion funkcias per OpenStreetMap.
 
 Fieblo: nelibera reto, ĉar serviloj funkcias per fermkoda programaro.
 

--- a/metadata/eo/description.txt
+++ b/metadata/eo/description.txt
@@ -8,6 +8,6 @@ Kelkaj fermkodaj partoj estis forigitaj el la originala kliento Telegramo, inklu
 
 Fieblo: nelibera reto, ĉar serviloj funkcias per fermkoda programaro.
 
-La oficiala fontkodo enhavas binaraĵojn, do en tiu ĉi ido oni kompilis ilin el fontkodoj.
+La oficiala fontkodo enhavas binaraĵojn, en tiu ĉi ido oni kompilis ilin el fontkodoj.
 
 Neoficiala esperantigo: <a href="https://t.me/setlanguage/eo-beta">https://t.me/setlanguage/eo-beta</a>

--- a/metadata/eo/summary.txt
+++ b/metadata/eo/summary.txt
@@ -1,1 +1,1 @@
-Telegramo estas komunikilo kun fokuso sur rapido kaj sekureco.
+Komunikilo kun fokuso al rapido kaj sekureco.

--- a/metadata/pl/description.txt
+++ b/metadata/pl/description.txt
@@ -1,11 +1,11 @@
-Uwaga: ta kompilacja jest w pełni otwartoźródłową odnogą, a programiści oryginalnej wersji z opóźnieniem publikują kod źródłowy najnowszych wydań.
+<b>Uwaga</b>: ta kompilacja jest w pełni otwartoźródłową odnogą, a programiści oryginalnej wersji z opóźnieniem publikują kod źródłowy najnowszych wydań, więc nowe wersje mogą być wydawane z pewnym opuźnieniem.
 
 Klient platformy komunikacyjnej Telegram. Rozmawiaj z przyjaciółmi, uczestnicz w czatach grupowych i dziel się dowolnym rodzajem treści. Wszystkie Twoje wiadomości i rozmowy są przechowywane w chmurze Telegram.
 
 Ta platforma komunikacji jest skoncentrowana głównie na urządzeniach mobilnych, ale są także dostępne klienty na komputer i przeglądarkę.
 
-Kilka własnościowych modułów zostało usuniętych z oryginalnego klienta Telegram, włączając Usługi Google Play dla usługi lokalizacji, HockeySDK dla automatycznych aktualizacji i powiadomienia «push» przez Google Cloud Messaging. Opcja udostępniania lokalizacji została przywrócona przez OpenStreetMap.
+Kilka własnościowych modułów zostało usuniętych z oryginalnego klienta Telegram, włączając Usługi Google Play (dla lokalizacji), HockeySDK (dla automatycznych aktualizacji) i powiadomienia «push» przez Google Cloud Messaging. Funkcja udostępniania lokalizacji została przywrócona używając OpenStreetMap.
 
 Niepożądana funkcja: niewolna sieć, serwery używają własnościowego oprogramowania.
 
-Oryginalny kod źródłowy zawiera binarki, więc ta wersja zawiera je skompilowe z kodu źródłowego. Z tego powodu nowe wersje mogą pojawić się z pewnym opóźnieniem.
+Oryginalny kod źródłowy zawiera binarki, ta wersja zawiera je skompilowane z kodu źródłowego.

--- a/metadata/pl/summary.txt
+++ b/metadata/pl/summary.txt
@@ -1,1 +1,1 @@
-Aplikacja do obsługi wiadomości, z naciskiem na szybkość i bezpieczeństwo.
+Komunikator z naciskiem na szybkość i bezpieczeństwo.


### PR DESCRIPTION
EO:
Aktualigis F-Droid-metadatumojn, movis la finan frazon al “averto”, ankaŭ aldonis ligilon al neoficiala esperantigo de la aplikaĵo.

EN:
Updated F-Droid metadata, moved the final sentence to "warning", also added a link to an unofficial Esperanto version of the application.