### PR TITLE
Fix 100% background CPU usage in FFmpeg

### DIFF
--- a/TMessagesProj/jni/gifvideo.cpp
+++ b/TMessagesProj/jni/gifvideo.cpp
@@ -240,11 +240,12 @@ int readCallback(void *opaque, uint8_t *buf, int buf_size) {
                 if (attached) {
                     javaVm->DetachCurrentThread();
                 }
-                return (int) read(info->fd, buf, (size_t) buf_size);
+                int ret = (int) read(info->fd, buf, (size_t) buf_size);
+                return ret ? ret : AVERROR_EOF;
             }
         }
     }
-    return 0;
+    return AVERROR_EOF;
 }
 
 int64_t seekCallback(void *opaque, int64_t offset, int whence) {


### PR DESCRIPTION
Since the update to Telegram FOSS 6.3.0, I have experienced issues with the app randomly starting to use 100% CPU (one core) forever in the background until it is killed manually, which wastes battery and causes the device to heat up. Running strace on the CPU-hogging thread revealed an endless stream of error messages being written to /dev/null (fd 2):

```
read(273, "", 0)                        = 0
write(2, "Invalid return value 0 for stream protocol\n", 43) = 43
read(273, "", 0)                        = 0
write(2, "Invalid return value 0 for stream protocol\n", 43) = 43
```

Upon further investigation, this error comes from newer versions of FFmpeg ([commit](https://git.videolan.org/?p=ffmpeg.git;a=commitdiff;h=a606f27f4c610708fa96e35eed7b7537d3d8f712)) as the packet read callback's expected return value on EOF has been changed. This commit fixes the issue by updating the packet read callback used to play videos with FFmpeg to return AVERROR_EOF on EOF instead of 0 as seen in [mpv](https://github.com/mpv-player/mpv/commit/e9dc4ac86f9dbd59147963d08ec8447bba3ed0bb).