### PR TITLE
[TF][FIX] 10 min wake up interval should be 600000 ms

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/ApplicationLoader.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/ApplicationLoader.java
@@ -243,7 +243,7 @@ public class ApplicationLoader extends Application {
             pendingIntent = PendingIntent.getBroadcast(applicationContext, 0, i, 0);
 
             am.cancel(pendingIntent);
-            am.setRepeating(AlarmManager.RTC_WAKEUP, System.currentTimeMillis(), 60000, pendingIntent);
+            am.setRepeating(AlarmManager.RTC_WAKEUP, System.currentTimeMillis(), 600000, pendingIntent);
             try {
                 Log.d("TFOSS", "Starting push service...");
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {


### PR DESCRIPTION
As showed in https://github.com/proletarius101/Telegram-FOSS/blob/f7f353af2732a01ea329f55a11cdfc602db309e9/TMessagesProj/src/main/java/org/telegram/messenger/ApplicationLoader.java#L239 the wake-up interval should be 10 minutes, which is 600000 ms, rather than 60000 ms.

Could mitigate https://github.com/Telegram-FOSS-Team/Telegram-FOSS/issues/486