### PR TITLE
[TF][PUSH] only wake up notification service

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/ApplicationLoader.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/ApplicationLoader.java
@@ -239,7 +239,7 @@ public class ApplicationLoader extends Application {
             Log.d("TFOSS", "Trying to start push service every 10 minutes");
             // Telegram-FOSS: unconditionally enable push service
             AlarmManager am = (AlarmManager) applicationContext.getSystemService(Context.ALARM_SERVICE);
-            Intent i = new Intent(applicationContext, NotificationService.class);
+            Intent i = new Intent(applicationContext, NotificationsService.class);
             pendingIntent = PendingIntent.getBroadcast(applicationContext, 0, i, 0);
 
             am.cancel(pendingIntent);

--- a/TMessagesProj/src/main/java/org/telegram/messenger/ApplicationLoader.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/ApplicationLoader.java
@@ -239,7 +239,7 @@ public class ApplicationLoader extends Application {
             Log.d("TFOSS", "Trying to start push service every 10 minutes");
             // Telegram-FOSS: unconditionally enable push service
             AlarmManager am = (AlarmManager) applicationContext.getSystemService(Context.ALARM_SERVICE);
-            Intent i = new Intent(applicationContext, ApplicationLoader.class);
+            Intent i = new Intent(applicationContext, NotificationService.class);
             pendingIntent = PendingIntent.getBroadcast(applicationContext, 0, i, 0);
 
             am.cancel(pendingIntent);


### PR DESCRIPTION
* consider using background services, e.g., using `AlarmManager` to receive messages
  * since both when telegram receives messages through FCM: https://github.com/DrKLO/Telegram/blob/42feed0f4273541c6fc670722e9faeaa50a2205e/TMessagesProj/src/main/java/org/telegram/messenger/GcmPushListenerService.java#L38-L47 or the original `NotificationService`: https://github.com/DrKLO/Telegram/blob/28eb8dfd0ef959fd5ad7d5d22f1d32879707c0a0/TMessagesProj/src/main/java/org/telegram/messenger/NotificationsService.java#L18-L22 basically just start `ApplicationLoader.postInitApplication();`, we may only execute it through `AlarmManager` periodically, or change https://github.com/Telegram-FOSS-Team/Telegram-FOSS/blob/02f172c4043fafd190e0cb625a34bf0dcc8755b8/TMessagesProj/src/main/java/org/telegram/messenger/ApplicationLoader.java#L242 to `NotificationsService.class`