### PR TITLE
Fix audio in Video stream

### DIFF
--- a/TMessagesProj/jni/build_ffmpeg_clang.sh
+++ b/TMessagesProj/jni/build_ffmpeg_clang.sh
@@ -75,6 +75,7 @@ function build_one {
 	--enable-avresample \
 	--enable-swscale \
 	--enable-protocol=file \
+	--enable-decoder=opus \
 	--enable-decoder=h264 \
 	--enable-decoder=mpeg4 \
 	--enable-decoder=mjpeg \


### PR DESCRIPTION
Telegram FOSS can not play audio in the channel's video stream. I guess it is caused by the missing opus codec.

![telegram-cloud-photo-size-5-6339022299402972674-y](https://user-images.githubusercontent.com/31475650/139593110-109236c3-c59e-4542-839d-8b4485530dd1.jpg)

After adding this compilation option, NekoX can play audio in the video stream.
https://github.com/NekoX-Dev/NekoX/commit/6aeb6f679e4385005a9df82a19ee20a48320ea27
