### PR TITLE
Added ability to set target platforms for FFmpeg and BoringSSL.

### DIFF
--- a/TMessagesProj/jni/build_boringssl.sh
+++ b/TMessagesProj/jni/build_boringssl.sh
@@ -7,31 +7,38 @@ function build_one {
 	cd ${CPU}
 
 	echo "Configuring..."
-	cmake -DANDROID_NATIVE_API_LEVEL=${API} -DANDROID_ABI=${CPU} -DCMAKE_BUILD_TYPE=Release -DANDROID_NDK=${NDK} -DCMAKE_TOOLCHAIN_FILE=$NDK/build/cmake/android.toolchain.cmake -GNinja -DCMAKE_MAKE_PROGRAM=${NINJA_PATH} ../..
-	
+	cmake \
+	-DANDROID_NATIVE_API_LEVEL=${API} \
+	-DANDROID_ABI=${CPU} \
+	-DCMAKE_BUILD_TYPE=Release \
+	-DANDROID_NDK=${NDK} \
+	-DCMAKE_TOOLCHAIN_FILE=${NDK}/build/cmake/android.toolchain.cmake \
+	-GNinja -DCMAKE_MAKE_PROGRAM=${NINJA_PATH} \
+	../..
+
 	echo "Building..."
 	cmake --build .
-	
+
 	cd ..
 }
 
 function checkPreRequisites {
 
-    if ! [ -d "boringssl" ] || ! [ "$(ls -A boringssl)" ]; then
-        echo -e "\033[31mFailed! Submodule 'boringssl' not found!\033[0m"
-        echo -e "\033[31mTry to run: 'git submodule init && git submodule update'\033[0m"
-        exit
-    fi
+	if ! [ -d "boringssl" ] || ! [ "$(ls -A boringssl)" ]; then
+		echo -e "\033[31mFailed! Submodule 'boringssl' not found!\033[0m"
+		echo -e "\033[31mTry to run: 'git submodule init && git submodule update'\033[0m"
+		exit
+	fi
 
-    if [ -z "$NDK" -a "$NDK" == "" ]; then
-        echo -e "\033[31mFailed! NDK is empty. Run 'export NDK=[PATH_TO_NDK]'\033[0m"
-        exit
-    fi
-    
-    if [ -z "$NINJA_PATH" -a "$NINJA_PATH" == "" ]; then
-        echo -e "\033[31mFailed! NINJA_PATH is empty. Run 'export NINJA_PATH=[PATH_TO_NINJA]'\033[0m"
-        exit
-    fi
+	if [ -z "$NDK" -a "$NDK" == "" ]; then
+		echo -e "\033[31mFailed! NDK is empty. Run 'export NDK=[PATH_TO_NDK]'\033[0m"
+		exit
+	fi
+
+	if [ -z "$NINJA_PATH" -a "$NINJA_PATH" == "" ]; then
+		echo -e "\033[31mFailed! NINJA_PATH is empty. Run 'export NINJA_PATH=[PATH_TO_NINJA]'\033[0m"
+		exit
+	fi
 }
 
 ANDROID_NDK=$NDK
@@ -39,20 +46,41 @@ checkPreRequisites
 
 cd boringssl
 
+rm -rf build
 mkdir build
 cd build
 
-API=16
+function build {
+	for arg in "$@"; do
+		case "${arg}" in
+			x86_64)
+				API=21
+				CPU=x86_64
+				build_one
+			;;
+			arm64)
+				API=21
+				CPU=arm64-v8a
+				build_one
+			;;
+			arm)
+				API=16
+				CPU=armeabi-v7a
+				build_one
+			;;
+			x86)
+				API=16
+				CPU=x86
+				build_one
+			;;
+			*)
+			;;
+		esac
+	done
+}
 
-CPU=armeabi-v7a
-build_one
-
-CPU=x86
-build_one
-
-API=21
-CPU=arm64-v8a
-build_one
-
-CPU=x86_64
-build_one
+if (( $# == 0 )); then
+	build x86_64 arm64 arm x86
+else
+	build $@
+fi

--- a/TMessagesProj/jni/build_ffmpeg_clang.sh
+++ b/TMessagesProj/jni/build_ffmpeg_clang.sh
@@ -1,32 +1,33 @@
 #!/bin/bash
 set -e
 function build_one {
-    CC="${CROSS_PREFIX}clang"
-    CXX="${CROSS_PREFIX}clang++"
-    AS="${CROSS_PREFIX}clang"
-    AR="${CROSS_PREFIX}ar"
-    LD="${CROSS_PREFIX}ld"
-    NM="${CROSS_PREFIX}nm"
-    STRIP="${CROSS_PREFIX}strip"
+	echo "Building ${ARCH}..."
+
+	PREBUILT=${NDK}/toolchains/${PREBUILT_ARCH}${PREBUILT_MIDDLE}-${VERSION}/prebuilt/${BUILD_PLATFORM}
+	PLATFORM=${NDK}/platforms/android-${ANDROID_API}/arch-${ARCH}
+
+	TOOLS_PREFIX="${LLVM_BIN}/${ARCH_NAME}-linux-${BIN_MIDDLE}-"
+
+	LD=${TOOLS_PREFIX}ld
+	AR=${TOOLS_PREFIX}ar
+	STRIP=${TOOLS_PREFIX}strip
+	NM=${TOOLS_PREFIX}nm
+
+	CC_PREFIX="${LLVM_BIN}/${CLANG_PREFIX}-linux-${BIN_MIDDLE}${ANDROID_API}-"
+
+	CC=${CC_PREFIX}clang
+	CXX=${CC_PREFIX}clang++
+	CROSS_PREFIX=${PREBUILT}/bin/${ARCH_NAME}-linux-${BIN_MIDDLE}-
 
 	echo "Cleaning..."
 	rm -f config.h
 	make clean || true
-	rm -rf ${TOOLCHAIN_PREFIX}
-	
-	echo "Toolchain..."
-	python $NDK/build/tools/make_standalone_toolchain.py \
-	--arch ${ARCH} \
-	--api ${ANDROID_API} \
-	--stl libc++ \
-	--install-dir=${TOOLCHAIN_PREFIX}
 
 	echo "Configuring..."
 
 	./configure \
 	--nm=${NM} \
 	--ar=${AR} \
-	--as=${CROSS_PREFIX}gcc \
 	--strip=${STRIP} \
 	--cc=${CC} \
 	--cxx=${CXX} \
@@ -34,17 +35,18 @@ function build_one {
 	--arch=$ARCH \
 	--target-os=linux \
 	--enable-cross-compile \
-	--x86asmexe=$NDK/prebuilt/$BUILD_PLATFORM/bin/yasm \
+	--x86asmexe=$NDK/prebuilt/${BUILD_PLATFORM}/bin/yasm \
 	--prefix=$PREFIX \
 	--enable-pic \
 	--disable-shared \
 	--enable-static \
-    --enable-asm \
-    --enable-inline-asm \
-    --enable-x86asm \
+	--enable-asm \
+	--enable-inline-asm \
+	--enable-x86asm \
 	--cross-prefix=$CROSS_PREFIX \
-	--sysroot=$SYSROOT \
+	--sysroot="${LLVM_PREFIX}/sysroot" \
 	--extra-cflags="-Wl,-Bsymbolic -Os -DCONFIG_LINUX_PERF=0 -DANDROID $OPTIMIZE_CFLAGS -fPIE -pie --static -fPIC" \
+	--extra-cxxflags="-Wl,-Bsymbolic -Os -DCONFIG_LINUX_PERF=0 -DANDROID $OPTIMIZE_CFLAGS -fPIE -pie --static -fPIC" \
 	--extra-ldflags="-Wl,-Bsymbolic -Wl,-rpath-link=$PLATFORM/usr/lib -L$PLATFORM/usr/lib -nostdlib -lc -lm -ldl -fPIC" \
 	\
 	--enable-version3 \
@@ -95,40 +97,40 @@ function build_one {
 
 function setCurrentPlatform {
 
-    PLATFORM="$(uname -s)"
-    case "${PLATFORM}" in
-        Darwin*)
-                    BUILD_PLATFORM=darwin-x86_64
-                    COMPILATION_PROC_COUNT=`sysctl -n hw.physicalcpu`
-                    ;;
-        Linux*)
-                    BUILD_PLATFORM=linux-x86_64
-                    COMPILATION_PROC_COUNT=$(nproc)
-                    ;;
-        *)
-                    echo -e "\033[33mWarning! Unknown platform ${PLATFORM}! falling back to linux-x86_64\033[0m"
-                    BUILD_PLATFORM=linux-x86_64
-                    COMPILATION_PROC_COUNT=1
-                    ;;
-    esac
+	CURRENT_PLATFORM="$(uname -s)"
+	case "${CURRENT_PLATFORM}" in
+		Darwin*)
+			BUILD_PLATFORM=darwin-x86_64
+			COMPILATION_PROC_COUNT=`sysctl -n hw.physicalcpu`
+			;;
+		Linux*)
+			BUILD_PLATFORM=linux-x86_64
+			COMPILATION_PROC_COUNT=$(nproc)
+			;;
+		*)
+			echo -e "\033[33mWarning! Unknown platform ${CURRENT_PLATFORM}! falling back to linux-x86_64\033[0m"
+			BUILD_PLATFORM=linux-x86_64
+			COMPILATION_PROC_COUNT=1
+			;;
+	esac
 
-    echo "build platform: ${BUILD_PLATFORM}"
-    echo "parallel jobs: ${COMPILATION_PROC_COUNT}"
+	echo "Build platform: ${BUILD_PLATFORM}"
+	echo "Parallel jobs: ${COMPILATION_PROC_COUNT}"
 
 }
 
 function checkPreRequisites {
 
-    if ! [ -d "ffmpeg" ] || ! [ "$(ls -A ffmpeg)" ]; then
-        echo -e "\033[31mFailed! Submodule 'ffmpeg' not found!\033[0m"
-        echo -e "\033[31mTry to run: 'git submodule init && git submodule update'\033[0m"
-        exit
-    fi
+	if ! [ -d "ffmpeg" ] || ! [ "$(ls -A ffmpeg)" ]; then
+		echo -e "\033[31mFailed! Submodule 'ffmpeg' not found!\033[0m"
+		echo -e "\033[31mTry to run: 'git submodule init && git submodule update'\033[0m"
+		exit
+	fi
 
-    if [ -z "$NDK" -a "$NDK" == "" ]; then
-        echo -e "\033[31mFailed! NDK is empty. Run 'export NDK=[PATH_TO_NDK]'\033[0m"
-        exit
-    fi
+	if [ -z "$NDK" -a "$NDK" == "" ]; then
+		echo -e "\033[31mFailed! NDK is empty. Run 'export NDK=[PATH_TO_NDK]'\033[0m"
+		exit
+	fi
 }
 
 setCurrentPlatform
@@ -139,56 +141,81 @@ checkPreRequisites
 
 cd ffmpeg
 
-BASEDIR=`pwd`
-TOOLCHAIN_PREFIX=${BASEDIR}/toolchain-android
-
 ## common
-SYSROOT=${TOOLCHAIN_PREFIX}/sysroot
+LLVM_PREFIX="${NDK}/toolchains/llvm/prebuilt/linux-x86_64"
+LLVM_BIN="${LLVM_PREFIX}/bin"
+VERSION="4.9"
 
-#x86_64
-ANDROID_API=21
-PREBUILT=$NDK/toolchains/x86_64-4.9/prebuilt/$BUILD_PLATFORM
-PLATFORM=$NDK/platforms/android-21/arch-x86_64
-CROSS_PREFIX=${TOOLCHAIN_PREFIX}/bin/x86_64-linux-android-
-ARCH=x86_64
-CPU=x86_64
-PREFIX=./build/$CPU
-ADDITIONAL_CONFIGURE_FLAG="--disable-asm"
-build_one
+function build {
+	for arg in "$@"; do
+		case "${arg}" in
+			x86_64)
+				ANDROID_API=21
 
-#arm64-v8a
-ANDROID_API=21
-PREBUILT=$NDK/toolchains/aarch64-linux-android-4.9/prebuilt/$BUILD_PLATFORM
-PLATFORM=$NDK/platforms/android-21/arch-arm64
-CROSS_PREFIX=${TOOLCHAIN_PREFIX}/bin/aarch64-linux-android-
-ARCH=arm64
-CPU=arm64-v8a
-OPTIMIZE_CFLAGS=
-PREFIX=./build/$CPU
-ADDITIONAL_CONFIGURE_FLAG="--enable-neon --enable-optimizations"
-build_one
+				ARCH=x86_64
+				ARCH_NAME=x86_64
+				PREBUILT_ARCH=x86_64
+				PREBUILT_MIDDLE=
+				CLANG_PREFIX=x86_64
+				BIN_MIDDLE=android
+				CPU=x86_64
+				PREFIX=./build/$CPU
+				ADDITIONAL_CONFIGURE_FLAG="--disable-asm"
+				build_one
+			;;
+			arm64)
+				ANDROID_API=21
 
+				ARCH=arm64
+				ARCH_NAME=aarch64
+				PREBUILT_ARCH=aarch64
+				PREBUILT_MIDDLE="-linux-android"
+				CLANG_PREFIX=aarch64
+				BIN_MIDDLE=android
+				CPU=arm64-v8a
+				OPTIMIZE_CFLAGS=
+				PREFIX=./build/$CPU
+				ADDITIONAL_CONFIGURE_FLAG="--enable-neon --enable-optimizations"
+				build_one
+			;;
+			arm)
+				ANDROID_API=16
 
-#arm v7n
-ANDROID_API=16
-PREBUILT=$NDK/toolchains/arm-linux-androideabi-4.9/prebuilt/$BUILD_PLATFORM
-PLATFORM=$NDK/platforms/android-16/arch-arm
-CROSS_PREFIX=${TOOLCHAIN_PREFIX}/bin/arm-linux-androideabi-
-ARCH=arm
-CPU=armv7-a
-OPTIMIZE_CFLAGS="-marm -march=$CPU"
-PREFIX=./build/armeabi-v7a
-ADDITIONAL_CONFIGURE_FLAG="--enable-neon"
-build_one
+				ARCH=arm
+				ARCH_NAME=arm
+				PREBUILT_ARCH=arm
+				PREBUILT_MIDDLE="-linux-androideabi"
+				CLANG_PREFIX=armv7a
+				BIN_MIDDLE=androideabi
+				CPU=armv7-a
+				OPTIMIZE_CFLAGS="-marm -march=$CPU"
+				PREFIX=./build/armeabi-v7a
+				ADDITIONAL_CONFIGURE_FLAG=--enable-neon
+				build_one
+			;;
+			x86)
+				ANDROID_API=16
 
-#x86 platform
-ANDROID_API=16
-PREBUILT=$NDK/toolchains/x86-4.9/prebuilt/$BUILD_PLATFORM
-PLATFORM=$NDK/platforms/android-16/arch-x86
-CROSS_PREFIX=${TOOLCHAIN_PREFIX}/bin/i686-linux-android-
-ARCH=x86
-CPU=i686
-OPTIMIZE_CFLAGS="-march=$CPU"
-PREFIX=./build/x86
-ADDITIONAL_CONFIGURE_FLAG="--disable-x86asm --disable-inline-asm --disable-asm"
-build_one
+				ARCH=x86
+				ARCH_NAME=i686
+				PREBUILT_ARCH=x86
+				PREBUILT_MIDDLE=
+				CLANG_PREFIX=i686
+				BIN_MIDDLE=android
+				CPU=i686
+				OPTIMIZE_CFLAGS="-march=$CPU"
+				PREFIX=./build/$CPU
+				ADDITIONAL_CONFIGURE_FLAG="--disable-x86asm --disable-inline-asm --disable-asm"
+				build_one
+			;;
+			*)
+			;;
+		esac
+	done
+}
+
+if (( $# == 0 )); then
+	build x86_64 arm64 arm x86
+else
+	build $@
+fi

--- a/TMessagesProj/jni/patch_ffmpeg.sh
+++ b/TMessagesProj/jni/patch_ffmpeg.sh
@@ -5,6 +5,10 @@ set -e
 patch -d ffmpeg -p1 < patches/ffmpeg/0001-compilation-magic.patch
 patch -d ffmpeg -p1 < patches/ffmpeg/0002-compilation-magic-2.patch
 
+function cp {
+	install -D $@
+}
+
 cp ffmpeg/libavformat/dv.h ffmpeg/build/arm64-v8a/include/libavformat/dv.h
 cp ffmpeg/libavformat/isom.h ffmpeg/build/arm64-v8a/include/libavformat/isom.h
 cp ffmpeg/libavformat/dv.h ffmpeg/build/armeabi-v7a/include/libavformat/dv.h


### PR DESCRIPTION
Additional improvements:
- Fixed #339.
- Fixed inconsistent indentations.

Since 3f4a7a302594527581039ee30d50d348de7bf593 `x86` and `x86_64` targets are not used, so FFmpeg and BoringSSL can be built only for arm.
```
./build_ffmpeg_clang.sh arm arm64
./build_boringssl.sh arm arm64
```
But I leave that on the maintainers.
An empty argument list leads to building of all targets.

Tested with the current `21.4.7075529` NDK.