### PR TITLE
Fix bug in onGetApplicationId: return package name instead of null

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/messenger/ApplicationLoader.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/ApplicationLoader.java
@@ -96,7 +96,7 @@ public class ApplicationLoader extends Application {
     }
 
     protected String onGetApplicationId() {
-        return null;
+        return getPackageName();
     }
 
     public static boolean isHuaweiStoreBuild() {


### PR DESCRIPTION
This patch fixes the missing package ID which is believed to be the cause of #624 .