### PR TITLE
Add Unified Push support

### DIFF
--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -5,7 +5,12 @@ apply plugin: 'com.android.library'
 repositories {
     mavenCentral()
     google()
-    maven { url 'https://www.jitpack.io' }
+    maven {
+        url 'https://www.jitpack.io'
+        content {
+            includeModule 'com.github.UnifiedPush', 'android-connector'
+        }
+    }
 }
 
 configurations {

--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.10'
     implementation 'com.google.guava:guava:31.1-android'
 
-    implementation 'com.github.UnifiedPush:android-connector:2.1.1'
+    implementation 'com.github.UnifiedPush:android-connector:2.2.0'
 
     implementation 'org.osmdroid:osmdroid-android:6.1.14'
 
@@ -84,8 +84,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
 
         coreLibraryDesugaringEnabled true
     }

--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'com.android.library'
 repositories {
     mavenCentral()
     google()
+    maven { url 'https://www.jitpack.io' }
 }
 
 configurations {
@@ -32,6 +33,8 @@ dependencies {
     implementation 'com.stripe:stripe-android:2.0.2'
     implementation 'com.google.code.gson:gson:2.10'
     implementation 'com.google.guava:guava:31.1-android'
+
+    implementation 'com.github.UnifiedPush:android-connector:2.1.1'
 
     implementation 'org.osmdroid:osmdroid-android:6.1.14'
 

--- a/TMessagesProj/config/debug/AndroidManifest.xml
+++ b/TMessagesProj/config/debug/AndroidManifest.xml
@@ -24,6 +24,15 @@
         android:requestLegacyExternalStorage="true"
         tools:replace="android:supportsRtl">
 
+        <receiver android:exported="true" android:enabled="true" android:name="org.telegram.messenger.UnifiedPushReceiver">
+            <intent-filter>
+                <action android:name="org.unifiedpush.android.connector.MESSAGE"/>
+                <action android:name="org.unifiedpush.android.connector.UNREGISTERED"/>
+                <action android:name="org.unifiedpush.android.connector.NEW_ENDPOINT"/>
+                <action android:name="org.unifiedpush.android.connector.REGISTRATION_FAILED"/>
+            </intent-filter>
+        </receiver>
+
     </application>
 
 </manifest>

--- a/TMessagesProj/config/debug/AndroidManifest_SDK23.xml
+++ b/TMessagesProj/config/debug/AndroidManifest_SDK23.xml
@@ -26,6 +26,15 @@
         android:requestLegacyExternalStorage="true"
         tools:replace="android:supportsRtl">
 
+        <receiver android:exported="true" android:enabled="true" android:name="org.telegram.messenger.UnifiedPushReceiver">
+            <intent-filter>
+                <action android:name="org.unifiedpush.android.connector.MESSAGE"/>
+                <action android:name="org.unifiedpush.android.connector.UNREGISTERED"/>
+                <action android:name="org.unifiedpush.android.connector.NEW_ENDPOINT"/>
+                <action android:name="org.unifiedpush.android.connector.REGISTRATION_FAILED"/>
+            </intent-filter>
+        </receiver>
+
     </application>
 
 </manifest>

--- a/TMessagesProj/config/release/AndroidManifest.xml
+++ b/TMessagesProj/config/release/AndroidManifest.xml
@@ -24,6 +24,15 @@
         android:requestLegacyExternalStorage="true"
         tools:replace="android:supportsRtl">
 
+        <receiver android:exported="true" android:enabled="true" android:name="org.telegram.messenger.UnifiedPushReceiver">
+            <intent-filter>
+                <action android:name="org.unifiedpush.android.connector.MESSAGE"/>
+                <action android:name="org.unifiedpush.android.connector.UNREGISTERED"/>
+                <action android:name="org.unifiedpush.android.connector.NEW_ENDPOINT"/>
+                <action android:name="org.unifiedpush.android.connector.REGISTRATION_FAILED"/>
+            </intent-filter>
+        </receiver>
+
     </application>
 
 </manifest>

--- a/TMessagesProj/config/release/AndroidManifest_SDK23.xml
+++ b/TMessagesProj/config/release/AndroidManifest_SDK23.xml
@@ -26,6 +26,15 @@
         android:requestLegacyExternalStorage="true"
         tools:replace="android:supportsRtl">
 
+        <receiver android:exported="true" android:enabled="true" android:name="org.telegram.messenger.UnifiedPushReceiver">
+            <intent-filter>
+                <action android:name="org.unifiedpush.android.connector.MESSAGE"/>
+                <action android:name="org.unifiedpush.android.connector.UNREGISTERED"/>
+                <action android:name="org.unifiedpush.android.connector.NEW_ENDPOINT"/>
+                <action android:name="org.unifiedpush.android.connector.REGISTRATION_FAILED"/>
+            </intent-filter>
+        </receiver>
+
     </application>
 
 </manifest>

--- a/TMessagesProj/config/release/AndroidManifest_standalone.xml
+++ b/TMessagesProj/config/release/AndroidManifest_standalone.xml
@@ -105,6 +105,16 @@
                 <category android:name="android.intent.category.MULTIWINDOW_LAUNCHER" />
             </intent-filter>
         </activity-alias>
+
+        <receiver android:exported="true" android:enabled="true" android:name="org.telegram.messenger.UnifiedPushReceiver">
+            <intent-filter>
+                <action android:name="org.unifiedpush.android.connector.MESSAGE"/>
+                <action android:name="org.unifiedpush.android.connector.UNREGISTERED"/>
+                <action android:name="org.unifiedpush.android.connector.NEW_ENDPOINT"/>
+                <action android:name="org.unifiedpush.android.connector.REGISTRATION_FAILED"/>
+            </intent-filter>
+        </receiver>
+
     </application>
 
 </manifest>

--- a/TMessagesProj/src/main/java/org/telegram/messenger/ApplicationLoader.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/ApplicationLoader.java
@@ -91,7 +91,7 @@ public class ApplicationLoader extends Application {
     }
 
     protected PushListenerController.IPushListenerServiceProvider onCreatePushProvider() {
-        return PushListenerController.GooglePushListenerServiceProvider.INSTANCE;
+        return PushListenerController.UnifiedPushListenerServiceProvider.INSTANCE;
     }
 
     public static String getApplicationId() {
@@ -210,7 +210,7 @@ public class ApplicationLoader extends Application {
         }
 
         ApplicationLoader app = (ApplicationLoader) ApplicationLoader.applicationContext;
-        //app.initPushServices();
+        app.initPushServices();
         if (BuildVars.LOGS_ENABLED) {
             FileLog.d("app initied");
         }
@@ -345,7 +345,7 @@ public class ApplicationLoader extends Application {
             e.printStackTrace();
         }
     }
-/*
+
     private void initPushServices() {
         AndroidUtilities.runOnUIThread(() -> {
             if (getPushProvider().hasServices()) {
@@ -360,6 +360,7 @@ public class ApplicationLoader extends Application {
         }, 1000);
     }
 
+/*
     private boolean checkPlayServices() {
         try {
             int resultCode = GooglePlayServicesUtil.isGooglePlayServicesAvailable(this);

--- a/TMessagesProj/src/main/java/org/telegram/messenger/UnifiedPushReceiver.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/UnifiedPushReceiver.java
@@ -1,0 +1,83 @@
+package org.telegram.messenger;
+
+import android.content.Context;
+import android.os.SystemClock;
+
+import androidx.annotation.NonNull;
+
+import org.telegram.tgnet.ConnectionsManager;
+import org.unifiedpush.android.connector.MessagingReceiver;
+
+import java.util.concurrent.CountDownLatch;
+
+public class UnifiedPushReceiver extends MessagingReceiver {
+    @Override
+    public void onNewEndpoint(Context context, String endpoint, String instance){
+        Utilities.globalQueue.postRunnable(() -> {
+            SharedConfig.pushStringGetTimeEnd = SystemClock.elapsedRealtime();
+
+            PushListenerController.sendRegistrationToServer(PushListenerController.PUSH_TYPE_SIMPLE, endpoint);
+        });
+    }
+
+    @Override
+    public void onMessage(Context context, byte[] message, String instance){
+        final long receiveTime = SystemClock.elapsedRealtime();
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+
+        AndroidUtilities.runOnUIThread(() -> {
+            if (BuildVars.LOGS_ENABLED) {
+                FileLog.d("UP PRE INIT APP");
+            }
+            ApplicationLoader.postInitApplication();
+            if (BuildVars.LOGS_ENABLED) {
+                FileLog.d("UP POST INIT APP");
+            }
+            Utilities.stageQueue.postRunnable(() -> {
+                if (BuildVars.LOGS_ENABLED) {
+                    FileLog.d("UP START PROCESSING");
+                }
+                for (int a = 0; a < UserConfig.MAX_ACCOUNT_COUNT; a++) {
+                    if (UserConfig.getInstance(a).isClientActivated()) {
+                        ConnectionsManager.onInternalPushReceived(a);
+                        ConnectionsManager.getInstance(a).resumeNetworkMaybe();
+                    }
+                }
+                countDownLatch.countDown();
+            });
+        });
+        Utilities.globalQueue.postRunnable(()-> {
+            try {
+                countDownLatch.await();
+            } catch (Throwable ignore) {
+
+            }
+            if (BuildVars.DEBUG_VERSION) {
+                FileLog.d("finished UP service, time = " + (SystemClock.elapsedRealtime() - receiveTime));
+            }
+        });
+    }
+
+    @Override
+    public void onRegistrationFailed(Context context, String instance){
+        if (BuildVars.LOGS_ENABLED) {
+            FileLog.d("Failed to get endpoint");
+        }
+        SharedConfig.pushStringStatus = "__UNIFIEDPUSH_FAILED__";
+        Utilities.globalQueue.postRunnable(() -> {
+            SharedConfig.pushStringGetTimeEnd = SystemClock.elapsedRealtime();
+
+            PushListenerController.sendRegistrationToServer(PushListenerController.PUSH_TYPE_SIMPLE, null);
+        });
+    }
+
+    @Override
+    public void onUnregistered(Context context, String instance){
+        SharedConfig.pushStringStatus = "__UNIFIEDPUSH_FAILED__";
+        Utilities.globalQueue.postRunnable(() -> {
+            SharedConfig.pushStringGetTimeEnd = SystemClock.elapsedRealtime();
+
+            PushListenerController.sendRegistrationToServer(PushListenerController.PUSH_TYPE_SIMPLE, null);
+        });
+    }
+}

--- a/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/INavigationLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ActionBar/INavigationLayout.java
@@ -293,6 +293,7 @@ public interface INavigationLayout {
         /**
          * @deprecated You should override {@link INavigationLayoutDelegate#needPresentFragment(INavigationLayout, NavigationParams)} for more fields
          */
+        @Deprecated
         default boolean needPresentFragment(BaseFragment fragment, boolean removeLast, boolean forceWithoutAnimation, INavigationLayout layout) {
             return true;
         }

--- a/TMessagesProj/src/main/java/org/telegram/ui/NotificationsSettingsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/NotificationsSettingsActivity.java
@@ -188,6 +188,7 @@ public class NotificationsSettingsActivity extends BaseFragment implements Notif
         otherSection2Row = rowCount++;
 
         otherSectionRow = rowCount++;
+        notificationsServiceRow = rowCount++;
         notificationsServiceConnectionRow = rowCount++;
         androidAutoAlertRow = -1;
         repeatRow = rowCount++;
@@ -654,15 +655,12 @@ public class NotificationsSettingsActivity extends BaseFragment implements Notif
                 enabled = preferences.getBoolean("pushConnection", getMessagesController().backgroundConnection);
                 SharedPreferences.Editor editor = preferences.edit();
                 editor.putBoolean("pushConnection", !enabled);
-                enabled = preferences.getBoolean("pushService", getMessagesController().keepAliveService);
-                editor.putBoolean("pushService", !enabled);
                 editor.commit();
                 if (!enabled) {
                     ConnectionsManager.getInstance(currentAccount).setPushConnectionEnabled(true);
                 } else {
                     ConnectionsManager.getInstance(currentAccount).setPushConnectionEnabled(false);
                 }
-                ApplicationLoader.startPushService();
             } else if (position == accountsAllRow) {
                 SharedPreferences preferences = MessagesController.getGlobalNotificationsSettings();
                 enabled = preferences.getBoolean("AllAccounts", true);
@@ -681,6 +679,13 @@ public class NotificationsSettingsActivity extends BaseFragment implements Notif
                         }
                     }
                 }
+            } else if (position == notificationsServiceRow) {
+                SharedPreferences preferences = MessagesController.getNotificationsSettings(currentAccount);
+                enabled = preferences.getBoolean("pushService", getMessagesController().keepAliveService);
+                SharedPreferences.Editor editor = preferences.edit();
+                editor.putBoolean("pushService", !enabled);
+                editor.commit();
+                ApplicationLoader.startPushService();
             } else if (position == callsVibrateRow) {
                 if (getParentActivity() == null) {
                     return;
@@ -940,6 +945,8 @@ public class NotificationsSettingsActivity extends BaseFragment implements Notif
                         checkCell.setTextAndCheck(LocaleController.getString("PinnedMessages", R.string.PinnedMessages), preferences.getBoolean("PinnedMessages", true), false);
                     } else if (position == androidAutoAlertRow) {
                         checkCell.setTextAndCheck("Android Auto", preferences.getBoolean("EnableAutoNotifications", false), true);
+                    } else if (position == notificationsServiceRow) {
+                        checkCell.setTextAndValueAndCheck(LocaleController.getString("NotificationsService", R.string.NotificationsService), "You won't be notified of new messages, if you disable this", preferences.getBoolean("pushService", getMessagesController().keepAliveService), true, true);
                     } else if (position == notificationsServiceConnectionRow) {
                         checkCell.setTextAndValueAndCheck(LocaleController.getString("NotificationsServiceConnection", R.string.NotificationsServiceConnection), "You won't be notified of new messages, if you disable this", preferences.getBoolean("pushConnection", getMessagesController().backgroundConnection), true, true);
                     } else if (position == badgeNumberShowRow) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/NotificationsSettingsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/NotificationsSettingsActivity.java
@@ -946,9 +946,9 @@ public class NotificationsSettingsActivity extends BaseFragment implements Notif
                     } else if (position == androidAutoAlertRow) {
                         checkCell.setTextAndCheck("Android Auto", preferences.getBoolean("EnableAutoNotifications", false), true);
                     } else if (position == notificationsServiceRow) {
-                        checkCell.setTextAndValueAndCheck(LocaleController.getString("NotificationsService", R.string.NotificationsService), "You won't be notified of new messages, if you disable this", preferences.getBoolean("pushService", getMessagesController().keepAliveService), true, true);
+                        checkCell.setTextAndValueAndCheck(LocaleController.getString("NotificationsService", R.string.NotificationsService), LocaleController.getString("NotificationsServiceInfo", R.string.NotificationsServiceInfo), preferences.getBoolean("pushService", getMessagesController().keepAliveService), true, true);
                     } else if (position == notificationsServiceConnectionRow) {
-                        checkCell.setTextAndValueAndCheck(LocaleController.getString("NotificationsServiceConnection", R.string.NotificationsServiceConnection), "You won't be notified of new messages, if you disable this", preferences.getBoolean("pushConnection", getMessagesController().backgroundConnection), true, true);
+                        checkCell.setTextAndValueAndCheck(LocaleController.getString("NotificationsServiceConnection", R.string.NotificationsServiceConnection), LocaleController.getString("NotificationsServiceConnectionInfo", R.string.NotificationsServiceConnectionInfo), preferences.getBoolean("pushConnection", getMessagesController().backgroundConnection), true, true);
                     } else if (position == badgeNumberShowRow) {
                         checkCell.setTextAndCheck(LocaleController.getString("BadgeNumberShow", R.string.BadgeNumberShow), getNotificationsController().showBadgeNumber, true);
                     } else if (position == badgeNumberMutedRow) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/NotificationsSettingsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/NotificationsSettingsActivity.java
@@ -9,6 +9,7 @@
 package org.telegram.ui;
 
 import android.app.Activity;
+import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -23,11 +24,14 @@ import android.util.LongSparseArray;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+
+import org.unifiedpush.android.connector.UnifiedPush;
 
 import org.telegram.messenger.AndroidUtilities;
 import org.telegram.messenger.ApplicationLoader;
@@ -53,6 +57,7 @@ import org.telegram.ui.ActionBar.Theme;
 import org.telegram.ui.ActionBar.ThemeDescription;
 import org.telegram.ui.Cells.HeaderCell;
 import org.telegram.ui.Cells.NotificationsCheckCell;
+import org.telegram.ui.Cells.RadioColorCell;
 import org.telegram.ui.Cells.ShadowSectionCell;
 import org.telegram.ui.Cells.TextCheckCell;
 import org.telegram.ui.Cells.TextDetailSettingsCell;
@@ -67,6 +72,8 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class NotificationsSettingsActivity extends BaseFragment implements NotificationCenter.NotificationCenterDelegate {
 
@@ -127,6 +134,7 @@ public class NotificationsSettingsActivity extends BaseFragment implements Notif
     private int badgeNumberSection2Row;
     private int androidAutoAlertRow;
     private int repeatRow;
+    private int unifiedPushDistributorRow;
     private int resetSection2Row;
     private int resetSectionRow;
     private int resetNotificationsRow;
@@ -136,6 +144,7 @@ public class NotificationsSettingsActivity extends BaseFragment implements Notif
     private boolean updateVibrate;
     private boolean updateRingtone;
     private boolean updateRepeatNotifications;
+    private boolean updateUnifiedPushDistributor;
 
     @Override
     public boolean onFragmentCreate() {
@@ -192,6 +201,7 @@ public class NotificationsSettingsActivity extends BaseFragment implements Notif
         notificationsServiceConnectionRow = rowCount++;
         androidAutoAlertRow = -1;
         repeatRow = rowCount++;
+        unifiedPushDistributorRow = rowCount++;
         resetSection2Row = rowCount++;
         resetSectionRow = rowCount++;
         resetNotificationsRow = rowCount++;
@@ -732,6 +742,45 @@ public class NotificationsSettingsActivity extends BaseFragment implements Notif
                 builder.setNegativeButton(LocaleController.getString("Cancel", R.string.Cancel), null);
                 showDialog(builder.create());
             }
+            else if (position == unifiedPushDistributorRow) {
+                AtomicReference<Dialog> dialogRef = new AtomicReference<>();
+
+                LinearLayout linearLayout = new LinearLayout(context);
+                linearLayout.setOrientation(LinearLayout.VERTICAL);
+
+                List<String> distributors = UnifiedPush.getDistributors(ApplicationLoader.applicationContext, new ArrayList<>());
+                CharSequence[] items = distributors.toArray(new CharSequence[distributors.size()]);
+
+                String distributor = UnifiedPush.getDistributor(ApplicationLoader.applicationContext);
+
+                for (int i = 0; i < items.length; ++i) {
+                    final int index = i;
+                    RadioColorCell cell = new RadioColorCell(getParentActivity());
+                    cell.setPadding(AndroidUtilities.dp(4), 0, AndroidUtilities.dp(4), 0);
+                    cell.setCheckColor(Theme.getColor(Theme.key_radioBackground), Theme.getColor(Theme.key_dialogRadioBackgroundChecked));
+                    cell.setTextAndValue(items[index], items[index].equals(distributor));
+                    cell.setBackground(Theme.createSelectorDrawable(Theme.getColor(Theme.key_listSelector), Theme.RIPPLE_MASK_ALL));
+                    linearLayout.addView(cell);
+                    cell.setOnClickListener(v -> {
+                        UnifiedPush.saveDistributor(ApplicationLoader.applicationContext, items[index].toString());
+                        UnifiedPush.registerApp(ApplicationLoader.applicationContext,
+                                "default",
+                                new ArrayList<String>(),
+                                "Telegram WebPush");
+                        updateUnifiedPushDistributor = true;
+                        adapter.notifyItemChanged(position);
+                        dialogRef.get().dismiss();
+                    });
+                }
+
+                Dialog dialog = new AlertDialog.Builder(getParentActivity())
+                        .setTitle(LocaleController.getString("UnifiedPushDistributor", R.string.UnifiedPushDistributor))
+                        .setView(linearLayout)
+                        .setNegativeButton(LocaleController.getString("Cancel", R.string.Cancel), null)
+                        .create();
+                dialogRef.set(dialog);
+                showDialog(dialog);
+            }
             if (view instanceof TextCheckCell) {
                 ((TextCheckCell) view).setChecked(!enabled);
             }
@@ -1086,6 +1135,10 @@ public class NotificationsSettingsActivity extends BaseFragment implements Notif
                         }
                         textCell.setTextAndValue(LocaleController.getString("RepeatNotifications", R.string.RepeatNotifications), value, updateRepeatNotifications, false);
                         updateRepeatNotifications = false;
+                    } else if (position == unifiedPushDistributorRow) {
+                        String value = UnifiedPush.getDistributor(ApplicationLoader.applicationContext);
+                        textCell.setTextAndValue(LocaleController.getString("UnifiedPushDistributor", R.string.UnifiedPushDistributor), value, updateUnifiedPushDistributor, false);
+                        updateUnifiedPushDistributor = false;
                     }
                     break;
                 }

--- a/TMessagesProj/src/main/res/values/strings.xml
+++ b/TMessagesProj/src/main/res/values/strings.xml
@@ -2526,6 +2526,7 @@
     <string name="DistanceUnitsAutomatic">Automatic</string>
     <string name="DistanceUnitsKilometers">Kilometers</string>
     <string name="DistanceUnitsMiles">Miles</string>
+    <string name="UnifiedPushDistributor">UnifiedPush Distributors</string>
     <string name="AuthAnotherClient">Scan QR Code</string>
     <string name="AuthAnotherClientScan">Scan QR Code</string>
     <string name="AuthAnotherClientTokenError">Token invalid or already expired.</string>

--- a/TMessagesProj_App/build.gradle
+++ b/TMessagesProj_App/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.application'
 repositories {
     mavenCentral()
     google()
+    maven { url 'https://www.jitpack.io' }
 }
 
 configurations {

--- a/TMessagesProj_App/build.gradle
+++ b/TMessagesProj_App/build.gradle
@@ -44,8 +44,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
 
         coreLibraryDesugaringEnabled true
     }

--- a/TMessagesProj_App/build.gradle
+++ b/TMessagesProj_App/build.gradle
@@ -3,7 +3,12 @@ apply plugin: 'com.android.application'
 repositories {
     mavenCentral()
     google()
-    maven { url 'https://www.jitpack.io' }
+    maven {
+        url 'https://www.jitpack.io'
+        content {
+            includeModule 'com.github.UnifiedPush', 'android-connector'
+        }
+    }
 }
 
 configurations {

--- a/TMessagesProj_AppStandalone/build.gradle
+++ b/TMessagesProj_AppStandalone/build.gradle
@@ -41,8 +41,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
 
         coreLibraryDesugaringEnabled true
     }

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.3'
+        // This is needed since android-connector:2.2.0 is built with Java 17
+        classpath 'com.android.tools:r8:8.2.33'
     }
 }
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@
 APP_VERSION_CODE=4082
 APP_VERSION_NAME=10.2.6
 APP_PACKAGE=org.telegram.messenger
-org.gradle.jvmargs=-Xmx4096M -XX:MaxPermSize=4096m
+org.gradle.jvmargs=-Xmx4096M -XX:MaxMetaspaceSize=4096m
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.configureondemand=false


### PR DESCRIPTION
This simple implementation only triggers the networks to resume when an
event is received, so Telegram can get the events by itself.

This is not like the other push providers where the change information
is processed by PushListenerController directly, but it still saves battery
since the process disconnects from Telegram servers as soon as the
updates are processed.

I also reverted ["[TF][PUSH] remove one of the confusing toggles"](https://github.com/Telegram-FOSS-Team/Telegram-FOSS/commit/53a496326f632c594edb61b0aa7898f36fec77bf), since with UnifiedPush it's worthless to enable the pushService when UnifiedPush is used.

It fixes #577