### PR TITLE
Fix Notification Request popup

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/NotificationPermissionDialog.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/NotificationPermissionDialog.java
@@ -154,7 +154,7 @@ public class NotificationPermissionDialog extends BottomSheet implements Notific
 
     @Override
     protected void onDismissWithTouchOutside() {
-        mayBeAccidentalDismiss = (System.currentTimeMillis() - showTime) < 3000L;
+        mayBeAccidentalDismiss = (System.currentTimeMillis() - showTime) < 1000L;
         super.onDismissWithTouchOutside();
     }
 


### PR DESCRIPTION
The original logic considered a denial before 3 seconds to be "accidental". Many users can read the popup and decide long before then, just to be asked again a day later.

I think it should be half a second (500), but 1 second is much better than 3

This should fix bug #752 , although the user was incorrect in their theory, they were just hitting it too quickly