### PR TITLE
Fix libFLAC: Exit at EOS in verify mode 

### DIFF
--- a/TMessagesProj/jni/exoplayer/libFLAC/stream_encoder.c
+++ b/TMessagesProj/jni/exoplayer/libFLAC/stream_encoder.c
@@ -2582,7 +2582,9 @@ FLAC__bool write_bitbuffer_(FLAC__StreamEncoder *encoder, uint32_t samples, FLAC
 			encoder->private_->verify.needs_magic_hack = true;
 		}
 		else {
-			if(!FLAC__stream_decoder_process_single(encoder->private_->verify.decoder)) {
+			if(!FLAC__stream_decoder_process_single(encoder->private_->verify.decoder)
+ 			    || (!is_last_block
+ 				    && (FLAC__stream_encoder_get_verify_decoder_state(encoder) == FLAC__STREAM_DECODER_END_OF_STREAM))) {
 				FLAC__bitwriter_release_buffer(encoder->private_->frame);
 				FLAC__bitwriter_clear(encoder->private_->frame);
 				if(encoder->protected_->state != FLAC__STREAM_ENCODER_VERIFY_MISMATCH_IN_AUDIO_DATA)


### PR DESCRIPTION
### Description
This pull request ports the patch from [xiph/flac@e1575e4](https://github.com/xiph/flac/commit/e1575e4a7c5157cbfe4a16dbd39b74f7174c7be) to this repository.

When verify mode is enabled, the encoder should terminate processing once the decoder flags end of stream (EOS). This ensures proper handling of the final block and prevents hanging or improper state transitions during verification.

### References
https://github.com/advisories/GHSA-crfc-rr25-6wf2