### PR TITLE
evdns: name_parse(): fix remote stack overread

### DIFF
--- a/TMessagesProj/jni/voip/webrtc/base/third_party/libevent/evdns.c
+++ b/TMessagesProj/jni/voip/webrtc/base/third_party/libevent/evdns.c
@@ -783,7 +783,6 @@ name_parse(u8 *packet, int length, int *idx, char *name_out, int name_out_len) {
 
 	for(;;) {
 		u8 label_len;
-		if (j >= length) return -1;
 		GET8(label_len);
 		if (!label_len) break;
 		if (label_len & 0xc0) {
@@ -804,6 +803,7 @@ name_parse(u8 *packet, int length, int *idx, char *name_out, int name_out_len) {
 			*cp++ = '.';
 		}
 		if (cp + label_len >= end) return -1;
+		if (j + label_len > length) return -1;
 		memcpy(cp, packet + j, label_len);
 		cp += label_len;
 		j += label_len;


### PR DESCRIPTION
Description
This PR added a bounds check before memcpy operation in name_parse() function to prevent potential out-of-bounds reads. This potential vulnerability was cloned from libevent and was fixed in [libevent/libevent@96f64a0](https://github.com/libevent/libevent/commit/96f64a0).

Reference:
[libevent/libevent@96f64a0](https://github.com/libevent/libevent/commit/96f64a0)
[CVE-2016-10195](https://nvd.nist.gov/vuln/detail/CVE-2016-10195)